### PR TITLE
PB-2593 Tweak the output of the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Kenect fork differences - why we forked it
+
+- Change database from PostgreSQL to Postgres to match non-bulk statements in NewRelic
+- Parse the SQL and set the collection and operation for bulk statements pretty much the way NewRelic appears to for non-bulk statements
+- If a statement starts with a /*...*/ comment, use its content as the collection name for the data sent to NewRelic
+
 [![New Relic Experimental header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Experimental.png)](https://opensource.newrelic.com/oss-category/#new-relic-experimental)
 
 # New Relic Java Instrumentation for JDBC executeBatch

--- a/jdbc-executeBatch/build.gradle
+++ b/jdbc-executeBatch/build.gradle
@@ -9,9 +9,13 @@ dependencies {
    // implementation 'javax.servlet:servlet-api:2.5'
 
    // New Relic Java Agent dependencies
-   implementation 'com.newrelic.agent.java:newrelic-agent:6.1.0'
-   implementation 'com.newrelic.agent.java:newrelic-api:6.1.0'
+   implementation 'com.newrelic.agent.java:newrelic-agent:7.7.0'
+   implementation 'com.newrelic.agent.java:newrelic-api:7.7.0'
    implementation fileTree(include: ['*.jar'], dir: '../libs')
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.assertj:assertj-core:3.11.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 jar {
@@ -23,6 +27,9 @@ jar {
   }
 }
 
+test {
+    useJUnitPlatform()
+}
 verifyInstrumentation {
   // Verifier plugin documentation:
   // https://github.com/newrelic/newrelic-gradle-verify-instrumentation

--- a/jdbc-executeBatch/src/main/java/com/nr/fit/instrumentation/jdbc/CollectionAndOperation.java
+++ b/jdbc-executeBatch/src/main/java/com/nr/fit/instrumentation/jdbc/CollectionAndOperation.java
@@ -1,0 +1,34 @@
+package com.nr.fit.instrumentation.jdbc;
+
+import java.util.Objects;
+
+public class CollectionAndOperation {
+    private final String collection;
+    private final String operation;
+
+    public CollectionAndOperation(String collection, String operation) {
+        this.collection = collection;
+        this.operation = operation;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {return true;}
+        if (o == null || getClass() != o.getClass()) {return false;}
+        CollectionAndOperation that = (CollectionAndOperation) o;
+        return collection.equals(that.collection) && operation.equals(that.operation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(collection, operation);
+    }
+}

--- a/jdbc-executeBatch/src/main/java/com/nr/fit/instrumentation/jdbc/Statement_instrumentation.java
+++ b/jdbc-executeBatch/src/main/java/com/nr/fit/instrumentation/jdbc/Statement_instrumentation.java
@@ -13,6 +13,8 @@ import com.newrelic.api.agent.weaver.NewField;
 import com.newrelic.api.agent.weaver.Weave;
 import com.newrelic.api.agent.weaver.Weaver;
 
+import static com.nr.fit.instrumentation.jdbc.DBUtils.DEFAULT_COLLECTION_AND_OPERATION;
+
 @Weave(originalName="java.sql.Statement",type=MatchType.Interface)
 public abstract class Statement_instrumentation {
 
@@ -30,7 +32,18 @@ public abstract class Statement_instrumentation {
 		List<String> batchQueries = DBUtils.getBatchQueries(hash);
 		int[] result =  Weaver.callOriginal();
 		int queriesExecuted = result.length; //preparedCount != null && preparedCount > 0 ? preparedCount : batchQueries.size();
-		DatastoreParameters params = DatastoreParameters.product(databaseVendor).collection("Batch").operation("execute").noInstance().noDatabaseName().slowQuery("", new BatchQueryConverter(queriesExecuted)).build();
+		CollectionAndOperation collectionAndOperation = DEFAULT_COLLECTION_AND_OPERATION;
+		if(!batchQueries.isEmpty()) {
+			collectionAndOperation = DBUtils.parse(batchQueries.get(0));
+		}
+		DatastoreParameters params = DatastoreParameters
+				.product(databaseVendor)
+				.collection(collectionAndOperation.getCollection())
+				.operation(collectionAndOperation.getOperation() + " batch")
+				.noInstance()
+				.noDatabaseName()
+				.slowQuery("", new BatchQueryConverter(queriesExecuted))
+				.build();
 		if(!batchQueries.isEmpty()) {
 			TracedMethod traced = NewRelic.getAgent().getTracedMethod();
 			int count = 1;

--- a/jdbc-executeBatch/src/test/java/com/nr/fit/instrumentation/jdbc/DBUtilsTest.java
+++ b/jdbc-executeBatch/src/test/java/com/nr/fit/instrumentation/jdbc/DBUtilsTest.java
@@ -1,0 +1,79 @@
+package com.nr.fit.instrumentation.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DBUtilsTest {
+
+    @Test
+    void testCollectionAndOperation1() {
+        assertThat(DBUtils.parse("SELECT * FROM blob"))
+                .extracting(CollectionAndOperation::getCollection, CollectionAndOperation::getOperation)
+                .containsExactly("blob", "select");
+    }
+
+    @Test
+    void testCollectionAndOperation2() {
+        assertThat(DBUtils.parse("WITH x(), y()SELECT * FROM blob"))
+                .extracting(CollectionAndOperation::getCollection, CollectionAndOperation::getOperation)
+                .containsExactly("blob", "select");
+    }
+
+    @Test
+    void testCollectionAndOperation_comment() {
+        assertThat(DBUtils.parse(
+                "/* Upsert contact */\n" +
+                        "INSERT INTO contact(id) values(?)"))
+                .extracting(CollectionAndOperation::getCollection, CollectionAndOperation::getOperation)
+                .containsExactly("Upsert contact", "batch");
+    }
+
+    @Test
+    void testCollectionAndOperation3() {
+        assertThat(DBUtils.parse("SELECT 1, a (SELECT a FROM b) FROM blob ORDER BY frog"))
+                .extracting(CollectionAndOperation::getCollection, CollectionAndOperation::getOperation)
+                .containsExactly("blob", "select");
+    }
+
+    @Test
+    void testCollectionAndOperation4() {
+        assertThat(DBUtils.parse("WITH tombstone AS (\n"
+                + "    INSERT INTO contact_tombstone(contact_id)\n"
+                + "    VALUES (:id)\n"
+                + "    ON CONFLICT DO NOTHING\n"
+                + ")\n"
+                + "DELETE FROM contact WHERE id = :id"))
+                .extracting(CollectionAndOperation::getCollection, CollectionAndOperation::getOperation)
+                .containsExactly("contact", "delete");
+    }
+
+    @Test
+    void testEmptyParentheticals1() {
+        assertThat(DBUtils.emptyParentheticals("SELECT * FROM blob")).isEqualTo("SELECT * FROM blob");
+    }
+
+    @Test
+    void testEmptyParentheticals2() {
+        assertThat(DBUtils.emptyParentheticals("SELECT a, (select 1) FROM blob"))
+                .isEqualTo("SELECT a, () FROM blob");
+    }
+
+    @Test
+    void testEmptyParentheticals3() {
+        assertThat(DBUtils.emptyParentheticals("WITH tombstone AS (\n"
+                + "    INSERT INTO contact_tombstone(contact_id)\n"
+                + "    VALUES (:id)\n"
+                + "    ON CONFLICT DO NOTHING\n"
+                + ")\n"
+                + "DELETE FROM contact WHERE id = :id"))
+                .isEqualTo("WITH tombstone AS ()\n"
+                        + "DELETE FROM contact WHERE id = :id");
+    }
+
+    @Test
+    void testEmptyParentheticals4() {
+        assertThat(DBUtils.emptyParentheticals("WITH x(), y()SELECT * FROM blob"))
+                .isEqualTo("WITH x(), y()SELECT * FROM blob");
+    }
+}


### PR DESCRIPTION
PostgreSQL -> Postgres (to be like the NewRelic agent)
Extract collection and operation from the statement (to be like the NewRelic agent)
Ignore CTEs (because we use them a lot and the NewRelic agent default output looks kinda silly)
Recognize /*...*/ comments and use the contents as collection if present
Add some unit tests for the new logic